### PR TITLE
Make SCons decide if bindings need to be generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The final step is to compile our C++ bindings library:
 
 ```bash
 cd godot-cpp
-scons platform=<your platform> generate_bindings=yes
+scons platform=<your platform>
 cd ..
 ```
 
@@ -116,7 +116,7 @@ Download the latest [Android NDK](https://developer.android.com/ndk/downloads)
 and set the NDK path.
 
 ```bash
-scons platform=android generate_bindings=yes ANDROID_NDK_ROOT="/PATH-TO-ANDROID-NDK/" android_arch=<arch>
+scons platform=android ANDROID_NDK_ROOT="/PATH-TO-ANDROID-NDK/" android_arch=<arch>
 ```
 
 The value of `android_arch` can be `armv7, arm64v8, x86, x86_64`. Most Android
@@ -136,6 +136,8 @@ You can optionally add the following options to the SCons command line:
 - To use an alternative `api.json` file, add `use_custom_api_file=yes
   custom_api_file=../api.json`. Be sure to specify the correct location where
   you placed your file (it can be a relative or absolute path).
+- To skip automatic generation of bindings (`src/gen` and `include/gen`), add `generate_bindings=no`.
+  This will use files in the gen directories as sources/headers, but not change them.
 
 ## Creating a simple class
 

--- a/binding_generator.py
+++ b/binding_generator.py
@@ -39,6 +39,37 @@ def print_file_list(api_filepath, output_dir, headers=False, sources=False):
         print(str(init_method_bindings_filename.as_posix()), end=end)
 
 
+def get_output_files(api_filepath, use_template_get_node, output_dir="."):
+    output_files = []
+
+    with open(api_filepath) as api_file:
+        classes = json.load(api_file)
+
+    include_gen_folder = Path(output_dir) / 'include' / 'gen'
+    source_gen_folder = Path(output_dir) / 'src' / 'gen'
+
+    for c in classes:
+        if use_template_get_node and c["name"] == "Node":
+            correct_method_name(c["methods"])
+
+        header_filename = include_gen_folder / (strip_name(c["name"]) + ".hpp")
+        output_files.append(header_filename)
+
+        source_filename = source_gen_folder / (strip_name(c["name"]) + ".cpp")
+        output_files.append(source_filename)
+
+    icall_header_filename = include_gen_folder / '__icalls.hpp'
+    output_files.append(icall_header_filename)
+
+    register_types_filename = source_gen_folder / '__register_types.cpp'
+    output_files.append(register_types_filename)
+
+    init_method_bindings_filename = source_gen_folder / '__init_method_bindings.cpp'
+    output_files.append(init_method_bindings_filename)
+
+    return output_files
+
+
 def generate_bindings(api_filepath, use_template_get_node, output_dir="."):
     global classes
     with open(api_filepath) as api_file:


### PR DESCRIPTION
Adds the binding generator as a SCons builder,
which allows using the api.json file as a dependency.

SCons will automatically trigger the binding generator
during build if a generated file is missing, or if the api.json changes.

This allows better utilization of the build cache,
as the bindings (and thus the library)
are not regenerated every time SCons runs.

Both arguments `auto` and `yes` for `generate_bindings` are accepted,
binding generation is only entirely skipped when passing `no`.